### PR TITLE
url wrapper seems to reference non existing file (/resources/example-index.html)

### DIFF
--- a/themes/default/hbs/wrapper.hbs
+++ b/themes/default/hbs/wrapper.hbs
@@ -8,7 +8,7 @@
 <body>
     <div id="dalekjs">
         <h1 id="dalekjs-header">
-            <a href="/resources/example-index.html">Dalek test</a>
+            <a href="index.html">Dalek test</a>
         </h1>
         {{{banner}}}
         <div id="dalekjs-testrunner-toolbar">


### PR DESCRIPTION
I just changed it to "index.html" so it references a file that definitely exists.
